### PR TITLE
BUG-FIX[Trainer]: check if overrides is not None before checking if it has a key in check_resume

### DIFF
--- a/ultralytics/engine/trainer.py
+++ b/ultralytics/engine/trainer.py
@@ -699,14 +699,16 @@ class BaseTrainer:
                 resume = True
                 self.args = get_cfg(ckpt_args)
                 self.args.model = self.args.resume = str(last)  # reinstate model
-                for k in (
-                    "imgsz",
-                    "batch",
-                    "device",
-                    "close_mosaic",
-                ):  # allow arg updates to reduce memory or update device on resume
-                    if k in overrides:
-                        setattr(self.args, k, overrides[k])
+
+                if overrides:
+                    for k in (
+                        "imgsz",
+                        "batch",
+                        "device",
+                        "close_mosaic",
+                    ):  # allow arg updates to reduce memory or update device on resume
+                        if k in overrides:
+                            setattr(self.args, k, overrides[k])
 
             except Exception as e:
                 raise FileNotFoundError(


### PR DESCRIPTION
When initializing trainer with `resume=True` and `overrides=None`, which is valid option, the method `check_resume` failing due to a line that check if some keys are in overrides, which is None so it's failing. 
This PR check that overrides is not None before checking if it has keys.